### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,10 +21,10 @@ class Item < ApplicationRecord
   has_one_attached :image
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
-  belongs_to :salesstatus
-  belongs_to :shippingfeestatus
+  belongs_to :sales_status
+  belongs_to :shipping_fee_status
   belongs_to :prefecture
-  belongs_to :scheduleddelivery
+  belongs_to :scheduled_delivery
 end
 
 # user_idのNOT FALSEはforeign_key :trueに含まれている

--- a/app/models/sales_status.rb
+++ b/app/models/sales_status.rb
@@ -1,4 +1,4 @@
-class Salesstatus < ActiveHash::Base
+class SalesStatus < ActiveHash::Base
   # ApplicationRecord から ActiveHash::Base に変更する必要がある
   self.data = [
     { id: 1, name: '---' },

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -1,9 +1,10 @@
-class Shippingfeestatus < ActiveHash::Base
+class ScheduledDelivery < ActiveHash::Base
   # ApplicationRecord から ActiveHash::Base に変更する必要がある
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' }
+    { id: 2, name: '1~2日で発送' },
+    { id: 3, name: '2~3日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/shipping_fee_status.rb
+++ b/app/models/shipping_fee_status.rb
@@ -1,10 +1,9 @@
-class Scheduleddelivery < ActiveHash::Base
+class ShippingFeeStatus < ActiveHash::Base
   # ApplicationRecord から ActiveHash::Base に変更する必要がある
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '1~2日で発送' },
-    { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送' }
+    { id: 2, name: '着払い(購入者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,24 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# sold out表示 購入機能実装のあとに追って実装 %>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          </div> %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +152,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+    <% unless Item.exists?%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,6 +176,7 @@
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -53,7 +53,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:sales_status_id, Salesstatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:sales_status_id, SalesStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -69,7 +69,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_status_id, Shippingfeestatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:scheduled_delivery_id, Scheduleddelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>


### PR DESCRIPTION
お世話になります。
掲題機能の実装が完了しました。

***
# 商品一覧表示機能の実装

## [commit] 商品一覧表示機能の実装

### 商品の表示
- 出品された商品が「画像/価格/品名/配送料の形式」の形で、新しい順に表示されるようコーディングしました。

### 備考
- コーディングの都合上、LGTM済のモデル名やコードを変更した箇所があります。
（ActiveHash用モデルファイル名とそのモデルを指定するコード、アソシエーションなど）
- 「sold out」表示については未実装のため、当該コードをコメントアウトしております。

### Gyazo
- 出品前と出品後の表示：https://gyazo.com/3f16b7f2f43879667875402c04e615ad
***

以上、ご確認お願い申し上げます。