### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :access_normalization, only: [:edit, :update, :destroy]
 
   def index
@@ -31,6 +31,14 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item.id)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if current_user == @item.user %>
       <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
     <% else %>
       <%# 売却済みの場合も表示されない処理は、購入機能実装のあとに追って実装 %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
お世話になります。
下記機能を実装しました。後日ご確認ください。
***
# 商品削除機能の実装

## [commit] 商品削除機能の実装
- 出品した商品をキャンセルできるようにするため、詳細ページの削除ボタンから商品の削除機能を実装しました。

### 備考
- 「売却済みの商品の削除機能への全てのアクセスをトップページへ送る」処理については未実装です。

### Gyazo
- 商品の削除：https://gyazo.com/c05ceed86267b4acfde2c185a5232d4b
***
以上、よろしくお願い申し上げます。